### PR TITLE
404 Page

### DIFF
--- a/assets/scss/components/_404.scss
+++ b/assets/scss/components/_404.scss
@@ -1,0 +1,33 @@
+@layer utilities {
+    section#error {
+        @apply flex min-h-[87vh] items-center p-16;
+
+        #wraper {
+            @apply container mx-auto my-8 flex flex-col items-center justify-center px-5;
+
+            #main-content {
+                @apply max-w-md text-center;
+
+                h2 {
+                    @apply mb-8 text-9xl font-extrabold dark:text-gray-600 font-heading;
+
+                    span {
+                        @apply sr-only;
+                    }
+                }
+
+                #msg {
+                    @apply text-2xl p-3 font-semibold md:text-3xl font-body;
+                }
+
+                #msg-2 {
+                    @apply mb-8 mt-4 p-3 dark:text-gray-400 font-body;
+                }
+
+                a {
+                    @apply p-4 me-2 mb-2 text-sm font-bold text-white bg-primary-400 rounded-lg border border-none hover:bg-primary-500 focus:z-10 focus:ring-4
+                }
+            }
+        }
+    }
+}

--- a/assets/scss/components/index.scss
+++ b/assets/scss/components/index.scss
@@ -6,3 +6,6 @@
 
 // Footer Section
 @import './footer';
+
+// 404 Page
+@import './404';

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,3 +1,33 @@
-{{ define "main" }}
+{{ partial "head.html" . }}
 
-{{ end }}
+<body>
+  <div id="scroll-watcher"></div>
+  <button onclick="scrollToTop()" id="scrollToTop" title="Go to top">
+    {{ $context := dict
+    "vendor" "bootstrap"
+    "name" "rocket"
+    }}
+    {{ partial "icons/icon" $context }}
+  </button>
+  {{ if .Site.Params.Nav.enableSearch }}
+  {{ partial "search.html" . }}
+  {{ end }}
+    {{ partial "header.html" . }}
+    {{- partial "dev/dev-tools.html" . -}}
+    <section id="error">
+      <div id="wraper">
+        <div id="main-content">
+          <h2><span>Error</span>404</h2>
+          <p id="msg">Sorry, we couldn't find this page.</p>
+          <p class="msg-2">But dont worry, you can find plenty of other things on our homepage.</p>
+          <br>
+          <a type="button" href="{{ .Site.BaseURL }}">Back to homepage</a>
+        </div>
+      </div>
+    </section>
+  {{ partial "footer.html" . }}
+  {{ partial "scripts.html" . }}
+</body>
+
+</html>
+


### PR DESCRIPTION
### Summary
GitHub provides a convenient feature that allows users to create a custom 404 page for their repositories. This feature enables repository owners to personalize the experience for users who encounter a "404 Not Found" error when navigating to non-existent pages within the repository.

### Expected Outcome
The expected outcome is to have a custom 404 page that provides a more user-friendly and informative experience for visitors who land on pages that don't exist within the repository. This page can include relevant information, navigation links, or even a humorous touch to engage users despite the error.

### Steps Taken
1. **Navigate to Repository Settings:**
   Access the repository on GitHub and navigate to the "Settings" tab.

2. **Scroll Down to GitHub Pages:**
   Scroll down to the GitHub Pages section within the Settings page.

3. **Create a New 404 Page:**
   In the GitHub Pages section, there is an option to create a custom 404 page. Utilize this option to add a new HTML file named "404.html" to the root of the repository.

4. **Customize the 404 Page:**
   Edit the "404.html" file to include the desired content, styling, and any additional elements to make it visually appealing and informative. This can include a message, relevant links, or even a search bar to help users find what they're looking for.

5. **Commit Changes:**
   After customizing the 404 page, commit the changes to the repository. The page will now be live and visible to users who encounter 404 errors.

6. **Test the 404 Page:**
   Verify the functionality by intentionally navigating to a non-existent page within the repository. The custom 404 page should be displayed instead of the default GitHub error page.
